### PR TITLE
[VCDA-1965] tkg+ upgrade scripts

### DIFF
--- a/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/docker-upgrade.sh
+++ b/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/docker-upgrade.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo 'upgrading packages to: docker-ce=5:19.03.12~3-0~ubuntu-xenial'
+apt-get -q update -o Acquire::Retries=3 -o Acquire::http::No-Cache=True -o Acquire::http::Timeout=30 -o Acquire::https::No-Cache=True -o Acquire::https::Timeout=30 -o Acquire::ftp::Timeout=30
+apt-get install -y --allow-change-held-packages docker-ce=5:19.03.12~3-0~ubuntu-xenial
+systemctl restart docker
+while [ `systemctl is-active docker` != 'active' ]; do echo 'waiting for docker'; sleep 5; done

--- a/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/master-cni-apply.sh
+++ b/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/master-cni-apply.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+export kubever=$(kubectl version --client | base64 | tr -d '\n')
+wget --no-verbose -O /root/weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v=2.6.5"
+kubectl apply -f /root/weave.yml
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/master-cni-apply.sh
+++ b/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/master-cni-apply.sh
@@ -5,5 +5,10 @@ set -e
 export kubever=$(kubectl version --client | base64 | tr -d '\n')
 wget --no-verbose -O /root/weave.yml "https://cloud.weave.works/k8s/net?k8s-version=$kubever&v=2.6.5"
 kubectl apply -f /root/weave.yml
+
+# pull weave docker images in case cluster has no outbound internet access
+docker pull weaveworks/weave-npc:2.6.5
+docker pull weaveworks/weave-kube:2.6.5
+
 systemctl restart kubelet
 while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/master-k8s-upgrade.sh
+++ b/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/master-k8s-upgrade.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -e
+
+
+# download Tanzu Kubernetes grid plus components and install them
+wget https://downloads.heptio.com/vmware-tanzu-kubernetes-grid/523a448aa3e9a0ef93ff892dceefee0a/vmware-kubernetes-v1.18.10%2Bvmware.1.tar.gz
+tar xvzf vmware-kubernetes-v1.18.10+vmware.1.tar.gz
+dpkg -i vmware-kubernetes-v1.18.10+vmware.1/debs/*.deb || :
+sudo apt-get -f install -y
+
+# kube proxy
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-proxy-v1.18.10_vmware.1.tar.gz
+
+# kube controller manager
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-controller-manager-v1.18.10_vmware.1.tar.gz
+
+# kube api server
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-apiserver-v1.18.10_vmware.1.tar.gz
+
+# kube scheduler
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-scheduler-v1.18.10_vmware.1.tar.gz
+
+# pause
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/pause-3.2.tar.gz
+
+# e2e test
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/e2e-test-v1.18.10_vmware.1.tar.gz
+
+# etcd
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/etcd-v3.4.3+vmware.11/images/etcd-v3.4.3_vmware.11.tar.gz
+
+# coredns
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/coredns-v1.6.7+vmware.6/images/coredns-v1.6.7_vmware.6.tar.gz
+
+docker tag registry.tkg.vmware.run/kube-proxy:v1.18.10_vmware.1 localhost:5000/kube-proxy:v1.18.10
+docker tag registry.tkg.vmware.run/kube-controller-manager:v1.18.10_vmware.1 localhost:5000/kube-controller-manager:v1.18.10
+docker tag registry.tkg.vmware.run/kube-apiserver:v1.18.10_vmware.1 localhost:5000/kube-apiserver:v1.18.10
+docker tag registry.tkg.vmware.run/kube-scheduler:v1.18.10_vmware.1 localhost:5000/kube-scheduler:v1.18.10
+docker tag registry.tkg.vmware.run/pause:3.2 localhost:5000/pause:3.2
+docker tag registry.tkg.vmware.run/e2e-test:v1.18.10_vmware.1 localhost:5000/e2e-test:v1.18.10
+docker tag registry.tkg.vmware.run/etcd:v3.4.3_vmware.11 localhost:5000/etcd:3.4.3-0
+docker tag registry.tkg.vmware.run/coredns:v1.6.7_vmware.6  localhost:5000/coredns:1.6.7
+
+docker push localhost:5000/kube-proxy:v1.18.10
+docker push localhost:5000/kube-controller-manager:v1.18.10
+docker push localhost:5000/kube-apiserver:v1.18.10
+docker push localhost:5000/kube-scheduler:v1.18.10
+docker push localhost:5000/pause:3.2
+docker push localhost:5000/e2e-test:v1.18.10
+docker push localhost:5000/etcd:3.4.3-0
+docker push localhost:5000/coredns:1.6.7
+
+# pull weave docker images in case cluster has no outbound internet access
+docker pull weaveworks/weave-npc:2.6.5
+docker pull weaveworks/weave-kube:2.6.5
+
+
+echo 'upgrading kubeadm to v1.18.10+vmware.1'
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done
+sleep 120
+kubeadm upgrade apply 1.18.10 -y
+
+
+# delete downloaded Tanzu Kubernetes grid plus
+rm -rf vmware-kubernetes-v1.18.10+vmware.1 || :
+rm vmware-kubernetes-v1.18.10+vmware.1.tar.gz || :
+
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done

--- a/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/worker-k8s-upgrade.sh
+++ b/scripts/ubuntu-16.04_tkgplus-1.18_weave-2.6.5_rev1/cluster-upgrade/worker-k8s-upgrade.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -e
+
+# download Tanzu Kubernetes grid plus components and install them
+wget https://downloads.heptio.com/vmware-tanzu-kubernetes-grid/523a448aa3e9a0ef93ff892dceefee0a/vmware-kubernetes-v1.18.10%2Bvmware.1.tar.gz
+tar xvzf vmware-kubernetes-v1.18.10+vmware.1.tar.gz
+dpkg -i vmware-kubernetes-v1.18.10+vmware.1/debs/*.deb || :
+sudo apt-get -f install -y
+
+# kube proxy
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-proxy-v1.18.10_vmware.1.tar.gz
+
+# kube controller manager
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-controller-manager-v1.18.10_vmware.1.tar.gz
+
+# kube api server
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-apiserver-v1.18.10_vmware.1.tar.gz
+
+# kube scheduler
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/kube-scheduler-v1.18.10_vmware.1.tar.gz
+
+# pause
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/pause-3.2.tar.gz
+
+# e2e test
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/kubernetes-v1.18.10+vmware.1/images/e2e-test-v1.18.10_vmware.1.tar.gz
+
+# etcd
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/etcd-v3.4.3+vmware.11/images/etcd-v3.4.3_vmware.11.tar.gz
+
+# coredns
+docker load < ./vmware-kubernetes-v1.18.10+vmware.1/coredns-v1.6.7+vmware.6/images/coredns-v1.6.7_vmware.6.tar.gz
+
+docker tag registry.tkg.vmware.run/kube-proxy:v1.18.10_vmware.1 localhost:5000/kube-proxy:v1.18.10
+docker tag registry.tkg.vmware.run/kube-controller-manager:v1.18.10_vmware.1 localhost:5000/kube-controller-manager:v1.18.10
+docker tag registry.tkg.vmware.run/kube-apiserver:v1.18.10_vmware.1 localhost:5000/kube-apiserver:v1.18.10
+docker tag registry.tkg.vmware.run/kube-scheduler:v1.18.10_vmware.1 localhost:5000/kube-scheduler:v1.18.10
+docker tag registry.tkg.vmware.run/pause:3.2 localhost:5000/pause:3.2
+docker tag registry.tkg.vmware.run/e2e-test:v1.18.10_vmware.1 localhost:5000/e2e-test:v1.18.10
+docker tag registry.tkg.vmware.run/etcd:v3.4.3_vmware.11 localhost:5000/etcd:3.4.3-0
+docker tag registry.tkg.vmware.run/coredns:v1.6.7_vmware.6  localhost:5000/coredns:1.6.7
+
+docker push localhost:5000/kube-proxy:v1.18.10
+docker push localhost:5000/kube-controller-manager:v1.18.10
+docker push localhost:5000/kube-apiserver:v1.18.10
+docker push localhost:5000/kube-scheduler:v1.18.10
+docker push localhost:5000/pause:3.2
+docker push localhost:5000/e2e-test:v1.18.10
+docker push localhost:5000/etcd:3.4.3-0
+docker push localhost:5000/coredns:1.6.7
+
+# pull weave docker images in case cluster has no outbound internet access
+docker pull weaveworks/weave-npc:2.6.5
+docker pull weaveworks/weave-kube:2.6.5
+
+
+echo 'upgrading kubeadm to v1.18.10+vmware.1'
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done
+sleep 120
+
+kubeadm upgrade node
+
+# delete downloaded Tanzu Kubernetes grid plus
+rm -rf vmware-kubernetes-v1.18.10+vmware.1 || :
+rm vmware-kubernetes-v1.18.10+vmware.1.tar.gz || :
+
+systemctl restart kubelet
+while [ `systemctl is-active kubelet` != 'active' ]; do echo 'waiting for kubelet'; sleep 5; done


### PR DESCRIPTION
- Upgrade scripts for tkg+ cluster
- Upgrading Kubernetes: 1.17.3 -> 1.18.10
- Testing done for the following
-- Create 1.17.3 cluster
-- Deploy application and verify it is up and running
-- check upgrade plan lists 1.18.10 for target upgrade
-- Upgrade the cluster to 1.18.10 ( with master and worker nodes )
-- verify the upgraded cluster has all components upgraded to 1.18.10 
-- verify the application deployed before the upgrade is still up and running after the upgrade
---------
![image](https://user-images.githubusercontent.com/5530442/104257738-f4f92a00-5432-11eb-9146-ba12b212ce08.png)

![image](https://user-images.githubusercontent.com/5530442/104257786-0f330800-5433-11eb-81d5-0af68018d4ff.png)

--After Upgrade
![image](https://user-images.githubusercontent.com/5530442/104257836-2bcf4000-5433-11eb-8665-8b4b7ac409c2.png)

---------------------


![image](https://user-images.githubusercontent.com/5530442/104675134-badd9180-5699-11eb-97da-355996ea4e0e.png)

-------------------------------------------------------
kubectl get cm -n kube-system kubeadm-config -o yaml
apiVersion: v1
data:
 ClusterConfiguration: |
  apiServer:
   extraArgs:
    authorization-mode: Node,RBAC
   timeoutForControlPlane: 4m0s
  apiVersion: kubeadm.k8s.io/v1beta2
  certificatesDir: /etc/kubernetes/pki
  clusterName: kubernetes
  controllerManager: {}
  dns:
   type: CoreDNS
  etcd:
   local:
    dataDir: /var/lib/etcd
  imageRepository: localhost:5000
  kind: ClusterConfiguration
  kubernetesVersion: v1.18.10
  networking:
   dnsDomain: cluster.local
   serviceSubnet: 10.96.0.0/12
  scheduler: {}
 ClusterStatus: |
  apiEndpoints:
   mstr-9ezo:
    advertiseAddress: 10.150.161.137
    bindPort: 6443
  apiVersion: kubeadm.k8s.io/v1beta2
  kind: ClusterStatus
kind: ConfigMap
metadata:
 creationTimestamp: “2021-01-14T19:02:43Z”
 name: kubeadm-config
 namespace: kube-system
 resourceVersion: “9073"
 selfLink: /api/v1/namespaces/kube-system/configmaps/kubeadm-config
 uid: 2148521c-0e1f-4dcf-ac9f-5fd984c08944
kubeadm config view
apiServer:
 extraArgs:
  authorization-mode: Node,RBAC
 timeoutForControlPlane: 4m0s
apiVersion: kubeadm.k8s.io/v1beta2
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
controllerManager: {}
dns:
 type: CoreDNS
etcd:
 local:
  dataDir: /var/lib/etcd
**imageRepository: localhost:5000**
kind: ClusterConfiguration
kubernetesVersion: v1.18.10
networking:
 dnsDomain: cluster.local
 serviceSubnet: 10.96.0.0/12
scheduler: {}

-----------------
kubeadm config view
apiServer:
 extraArgs:
  authorization-mode: Node,RBAC
 timeoutForControlPlane: 4m0s
apiVersion: kubeadm.k8s.io/v1beta2
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
controllerManager: {}
dns:
 type: CoreDNS
etcd:
 local:
  dataDir: /var/lib/etcd
**imageRepository: localhost:5000**
kind: ClusterConfiguration
kubernetesVersion: v1.18.10
networking:
 dnsDomain: cluster.local
 serviceSubnet: 10.96.0.0/12
scheduler: {}

---------------


@andrew-ni @anirudh9794 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andrew-ni/container-service-extension-templates/2)
<!-- Reviewable:end -->
